### PR TITLE
Replace debug include in LinuxAssetManager.cpp and remove unnessary library paths

### DIFF
--- a/Qube2D.pro
+++ b/Qube2D.pro
@@ -45,7 +45,7 @@ win32-g++ {
 }
 
 win32:  LIBS += -lopengl32 -lgdi32
-unix:   LIBS += -lGL -lX11 -lXi -lXrandr -lXxf86vm -lXinerama -lXcursor -pthread -dl
+unix:   LIBS += -lGL -lX11 -lXi -lXrandr -lXxf86vm -lXinerama -lXcursor -pthread  -lglfw -lfreetype -dl
 
 
 #

--- a/Qube2D.pro
+++ b/Qube2D.pro
@@ -39,10 +39,7 @@ DEPENDPATH  += $$PWD/include
 #
 #  Dependencies
 #
-linux-g++* {
-    LIBS += -L$$PWD/lib/glfw-3.2/linux/ -lglfw-3.2
-    LIBS += -L$$PWD/lib/freetype-2.3.5/linux/ -lfreetype
-} else:win32-g++ {
+win32-g++ {
     LIBS += -L$$PWD/lib/glfw-3.2/win32/ -lglfw-3.2
     LIBS += -L$$PWD/lib/freetype-2.3.5/win32/ -lfreetype
 }

--- a/src/Assets/Linux/LinuxAssetManager.cpp
+++ b/src/Assets/Linux/LinuxAssetManager.cpp
@@ -36,7 +36,7 @@
 ///////////////////////////////////////////////////////////
 #include <Qube2D/Assets/Linux/LinuxAssetManager.hpp>
 #include <Qube2D/Assets/AssetErrors.hpp>
-#include <Qube2D/System/Debug.hpp>
+#include <Qube2D/Debug/Debug.hpp>
 #include <cstdio>
 #include <vector>
 #include <unistd.h>


### PR DESCRIPTION
Fix for issue #2 *Building on Linux, Qube2D/System/Debug.hpp: No such file or directory*.

Fix for issue #4 *Set library paths disrupts linking on Linux*.